### PR TITLE
Add .gitignore for Python and Blender caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Python bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Blender cache directories
+blendcache*/
+*.blend1
+*.blend2
+
+# Transient files
+.DS_Store
+*.log
+*.tmp
+*.swp
+*~
+Thumbs.db


### PR DESCRIPTION
## Summary
- add .gitignore ignoring Python bytecode, Blender cache directories, and common transient files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4edb96f808325aba2c1df510ef9bf