### PR TITLE
Add overlay and post-FX module skeletons

### DIFF
--- a/scbw_gen/overlay/__init__.py
+++ b/scbw_gen/overlay/__init__.py
@@ -1,0 +1,1 @@
+"""Modules for user interface overlays."""

--- a/scbw_gen/overlay/overlay_driver.py
+++ b/scbw_gen/overlay/overlay_driver.py
@@ -1,0 +1,12 @@
+"""Overlay driver module.
+
+This module acts as the entry point for managing UI overlays within SCBW-Gen.
+"""
+
+
+def run_overlay() -> None:
+    """Execute overlay logic.
+
+    This placeholder function will later coordinate overlay creation and updates.
+    """
+    raise NotImplementedError("Overlay driver logic not implemented yet.")

--- a/scbw_gen/overlay/ui_overlay_config.yaml
+++ b/scbw_gen/overlay/ui_overlay_config.yaml
@@ -1,0 +1,9 @@
+# Configuration for UI overlays.
+# Placeholder values; update once overlay parameters are defined.
+
+overlay:
+  enabled: true
+  opacity: 0.8
+  position:
+    x: 0
+    y: 0

--- a/scbw_gen/post_fx/__init__.py
+++ b/scbw_gen/post_fx/__init__.py
@@ -1,0 +1,1 @@
+"""Post-processing effects modules."""

--- a/scbw_gen/post_fx/post_fx_compositor.py
+++ b/scbw_gen/post_fx/post_fx_compositor.py
@@ -1,0 +1,21 @@
+"""Post-processing compositor module.
+
+Combines render passes and applies post-processing effects.
+"""
+
+from typing import Any
+
+
+def compose_effects(frame: Any) -> Any:
+    """Apply post-processing effects to a frame.
+
+    Args:
+        frame: The input frame to process.
+
+    Returns:
+        The processed frame.
+
+    This function is a placeholder and should be implemented with actual
+    post-processing logic.
+    """
+    raise NotImplementedError("Post FX compositor not implemented yet.")


### PR DESCRIPTION
## Summary
- introduce placeholder overlay driver with initial configuration
- add post-processing compositor module skeleton for future effects

## Testing
- `pytest`
- `python -m py_compile scbw_gen/overlay/overlay_driver.py scbw_gen/post_fx/post_fx_compositor.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4ee6d2f98832599cea4bbdd3af2ee