### PR TITLE
feat: add YAML loader and sample params

### DIFF
--- a/params/pack.json
+++ b/params/pack.json
@@ -1,0 +1,42 @@
+{
+  "seed": 1337,
+  "image_size": [1280, 720],
+  "shots": [
+    {
+      "id": "shot_1001",
+      "palette": [[0.07,0.13,0.09],[0.12,0.2,0.14],[0.17,0.27,0.19]],
+      "portal": { "center": [0.5,0.5], "radius": 0.18, "falloff": 0.22, "invert": false },
+      "left_cluster":  { "rect": [0.08,0.45], "count": 6, "size": [18,36] },
+      "right_cluster": { "rect": [0.62,0.55], "count": 3, "size": [18,36] },
+      "hud": {
+        "left":  { "Race": "Terran",  "M": 2000, "G": 1000, "Supply": [60,80], "APM": 180 },
+        "right": { "Race": "Zerg",    "M": 2000, "G": 1000, "Supply": [62,90], "APM": 220 }
+      },
+      "export": { "png": true, "exr16": true }
+    },
+    {
+      "id": "shot_1002",
+      "palette": "ArmyColors",
+      "portal": { "center": [0.52,0.48], "radius": 0.21, "falloff": 0.20, "invert": false },
+      "left_cluster":  { "rect": [0.10,0.40], "count": 7, "size": [16,32] },
+      "right_cluster": { "rect": [0.60,0.55], "count": 4, "size": [20,38] },
+      "hud": {
+        "left":  { "Race": "Protoss", "M": 2400, "G": 1200, "Supply": [58,78], "APM": 195 },
+        "right": { "Race": "Zerg",    "M": 2100, "G": 900,  "Supply": [66,92], "APM": 225 }
+      },
+      "export": { "png": true, "exr16": false }
+    },
+    {
+      "id": "shot_1003",
+      "palette": [[0.05,0.10,0.12],[0.10,0.18,0.22],[0.16,0.26,0.30]],
+      "portal": { "center": [0.47,0.54], "radius": 0.16, "falloff": 0.25, "invert": false },
+      "left_cluster":  { "rect": [0.07,0.42], "count": 9, "size": [14,28] },
+      "right_cluster": { "rect": [0.63,0.52], "count": 5, "size": [22,42] },
+      "hud": {
+        "left":  { "Race": "Terran",  "M": 1800, "G": 900,  "Supply": [54,78], "APM": 205 },
+        "right": { "Race": "Protoss", "M": 2200, "G": 1100, "Supply": [60,86], "APM": 190 }
+      },
+      "export": { "png": true, "exr16": true }
+    }
+  ]
+}

--- a/params/pack.yaml
+++ b/params/pack.yaml
@@ -1,0 +1,32 @@
+seed: 1337
+image_size: [1280, 720]
+shots:
+  - id: shot_1001
+    palette: [[0.07,0.13,0.09],[0.12,0.2,0.14],[0.17,0.27,0.19]]
+    portal: { center: [0.5,0.5], radius: 0.18, falloff: 0.22, invert: false }
+    left_cluster:  { rect: [0.08,0.45], count: 6, size: [18,36] }
+    right_cluster: { rect: [0.62,0.55], count: 3, size: [18,36] }
+    hud:
+      left:  { Race: Terran,  M: 2000, G: 1000, Supply: [60,80], APM: 180 }
+      right: { Race: Zerg,    M: 2000, G: 1000, Supply: [62,90], APM: 220 }
+    export: { png: true, exr16: true }
+
+  - id: shot_1002
+    palette: ArmyColors
+    portal: { center: [0.52,0.48], radius: 0.21, falloff: 0.20, invert: false }
+    left_cluster:  { rect: [0.10,0.40], count: 7, size: [16,32] }
+    right_cluster: { rect: [0.60,0.55], count: 4, size: [20,38] }
+    hud:
+      left:  { Race: Protoss, M: 2400, G: 1200, Supply: [58,78], APM: 195 }
+      right: { Race: Zerg,    M: 2100, G:  900, Supply: [66,92], APM: 225 }
+    export: { png: true, exr16: false }
+
+  - id: shot_1003
+    palette: [[0.05,0.10,0.12],[0.10,0.18,0.22],[0.16,0.26,0.30]]
+    portal: { center: [0.47,0.54], radius: 0.16, falloff: 0.25, invert: false }
+    left_cluster:  { rect: [0.07,0.42], count: 9, size: [14,28] }
+    right_cluster: { rect: [0.63,0.52], count: 5, size: [22,42] }
+    hud:
+      left:  { Race: Terran,  M: 1800, G: 900, Supply: [54,78], APM: 205 }
+      right: { Race: Protoss, M: 2200, G: 1100, Supply: [60,86], APM: 190 }
+    export: { png: true, exr16: true }

--- a/wolfram/generate.wl
+++ b/wolfram/generate.wl
@@ -1,0 +1,66 @@
+(* ========= YAML/JSON loader ========= *)
+ClearAll[LoadParams];
+
+Options[LoadParams] = {"Prefer" -> Automatic};  (* "YAML"|"JSON"|Automatic *)
+
+LoadParams[path_, OptionsPattern[]] := Module[
+  {ext = ToLowerCase@FileExtension[path], prefer = OptionValue["Prefer"], data, tryWL, tryPy},
+  
+  tryWL[f_, fmt_] := Quiet @ Check[Import[f, fmt], $Failed];
+  
+  tryPy[f_] := Module[{ev = FindExternalEvaluators["Python"], sess, txt, res},
+    If[ev === {} , Return[$Failed]];
+    sess = StartExternalSession[First@ev];
+    res = ExternalEvaluate[sess, "
+import json, sys
+try:
+    import yaml
+except ImportError:
+    sys.exit('no_yaml')
+import io, os
+p = r'''" + f + "''' 
+with io.open(p, 'r', encoding='utf-8') as fp:
+    d = yaml.safe_load(fp)
+print(json.dumps(d))
+"];
+    KillExternalSession[sess];
+    If[res === "no_yaml", Return[$Failed]];
+    ImportString[res, "RawJSON"]
+  ];
+  
+  Which[
+    (* explicit preference *)
+    prefer === "JSON" || ext === "json", Import[path, "RawJSON"],
+    prefer === "YAML" || ext === "yaml" || ext === "yml",
+      With[{r1 = tryWL[path, "YAML"]}, If[r1 =!= $Failed, r1, tryPy[path]]],
+    True,  (* Automatic by extension *)
+      Switch[ext,
+        "json", Import[path, "RawJSON"],
+        "yaml" | "yml", With[{r1 = tryWL[path, "YAML"]}, If[r1 =!= $Failed, r1, tryPy[path]]],
+        _, Message[LoadParams::ext, ext]; $Failed
+      ]
+  ]
+];
+
+LoadParams::ext = "Невідоме розширення: `1`.";
+
+proj    = NotebookDirectory[] /. $Failed :> DirectoryName[$InputFileName];
+root    = FileNameJoin[{proj, ".."}];
+
+(* allow both JSON and YAML *)
+paramFN = If[FileExistsQ@FileNameJoin[{root, "params", "pack.yaml"}],
+             FileNameJoin[{root, "params", "pack.yaml"}],
+             FileNameJoin[{root, "params", "pack.json"}]
+           ];
+
+outDir  = FileNameJoin[{root, "out", "wl"}];
+If[!DirectoryQ[outDir], CreateDirectory[outDir, CreateIntermediateDirectories->True]];
+
+params = LoadParams[paramFN];
+If[params === $Failed, Print["⛘ Не вдалося завантажити параметри: ", paramFN]; Abort[]];
+
+SeedRandom[Lookup[params, "seed", 1337]];
+{w, h} = Lookup[params, "image_size", {1280, 720}];
+
+(* main logic placeholder *)
+Print["Loaded parameters: ", params];


### PR DESCRIPTION
## Summary
- support YAML or JSON parameters in Wolfram generator
- add sample pack.yaml and equivalent pack.json

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c003582ff48325905a6b330c1ff746