### PR TITLE
Add requirements file for Houdini YAML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,17 @@ SCBW-Gen (StarCraft: Brood War Generator) is a collection of tools for building 
      hython --version
      ```
    - (Optional) Set `HOUDINI_PATH` or project-specific environment variables if your studio pipeline requires them. See `houdini/README.md` (to be added) for detailed environment notes.
-3. **Install helper Python dependencies (optional)**
-   If you plan to use the standalone utilities, create a virtual environment and install the requirements:
+3. **Install helper Python dependencies**
+   The Houdini automation scripts rely on [`pyyaml`](https://pyyaml.org/) to read `.yaml` pack descriptions. Create a virtual environment and install the bundled requirements before running the utilities:
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate  # Linux/macOS
    .venv\Scripts\activate    # Windows
    pip install -r requirements.txt
+   ```
+   After installation you can confirm that YAML loading is available:
+   ```bash
+   python -c "import yaml; print('pyyaml ready')"
    ```
 
 ## Houdini Automation Workflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Dependencies for Houdini automation helpers
+pyyaml>=6.0


### PR DESCRIPTION
## Summary
- add a requirements.txt that records the PyYAML dependency for Houdini automation utilities
- update the setup instructions to install the requirements file and note the YAML availability check

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cad9587d708325a892d5dc812d7e5a