### PR TITLE
Fix dry-run packed EXR simulation

### DIFF
--- a/houdini/passes.py
+++ b/houdini/passes.py
@@ -98,7 +98,7 @@ class PassAssembler:
             if dry_run or hou is None:
                 LOG.info("Dry-run mode active; skipping Houdini execution for shot %s", shot.id)
                 manifest.pass_paths = self._simulate_pass_paths(shot)
-                manifest.packed_exr = self.output_directory / f"{shot.id}.exr"
+                manifest.packed_exr = self._simulate_packed_exr_path(shot)
                 manifests.append(manifest)
                 continue
 
@@ -216,6 +216,11 @@ class PassAssembler:
         for plane in self.passes:
             simulated[plane] = self.output_directory / "passes" / shot.id / f"{shot.id}_{plane}.exr"
         return simulated
+
+    def _simulate_packed_exr_path(self, shot: ShotParameters) -> Optional[Path]:
+        if not self.exr_driver:
+            return None
+        return self.output_directory / f"{shot.id}.exr"
 
 
 __all__ = [

--- a/tests/test_pass_assembler.py
+++ b/tests/test_pass_assembler.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from houdini.config import PackConfig, ShotParameters
+from houdini.passes import PassAssembler
+
+
+def test_process_shots_dry_run_without_exr_driver(tmp_path):
+    config = PackConfig(path=tmp_path / "pack.yaml", data={"shots": []})
+    assembler = PassAssembler(
+        config=config,
+        output_directory=tmp_path,
+        exr_driver=None,
+    )
+
+    shot = ShotParameters(id="shot001", raw={"id": "shot001"})
+
+    manifests = assembler.process_shots([shot], dry_run=True)
+
+    assert len(manifests) == 1
+    manifest = manifests[0]
+
+    assert manifest.pass_paths
+    assert manifest.packed_exr is None


### PR DESCRIPTION
## Summary
- ensure PassAssembler dry-run simulation only reports a packed EXR when an EXR driver is configured
- add a helper to compute the simulated packed EXR path
- add unit coverage for dry-run execution without an EXR driver configured

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cb13f83b98832581404d897e1e4362