### PR TITLE
Handle config parse errors consistently

### DIFF
--- a/houdini/config.py
+++ b/houdini/config.py
@@ -63,11 +63,17 @@ def load_pack_config(path: Path) -> PackConfig:
         )
 
     if path.suffix.lower() == ".json":
-        data = json.loads(path.read_text())
+        try:
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError as exc:
+            raise ConfigError(f"Failed to parse JSON configuration at '{path}': {exc}") from exc
     else:
         if yaml is None:
             raise ConfigError("pyyaml is required to load YAML configuration files.")
-        data = yaml.safe_load(path.read_text())  # type: ignore[arg-type]
+        try:
+            data = yaml.safe_load(path.read_text())  # type: ignore[arg-type]
+        except yaml.YAMLError as exc:  # type: ignore[attr-defined]
+            raise ConfigError(f"Failed to parse YAML configuration at '{path}': {exc}") from exc
 
     if not isinstance(data, MutableMapping):
         raise ConfigError(f"Configuration root must be a mapping, got: {type(data)!r}")

--- a/tests/test_generate_passes.py
+++ b/tests/test_generate_passes.py
@@ -1,8 +1,12 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from houdini import config as config_module
+from houdini.config import ConfigError, load_pack_config
 from houdini.generate_passes import _parse_arguments
 
 
@@ -30,3 +34,24 @@ def test_parse_arguments_falls_back_to_json(monkeypatch, tmp_path):
 
     assert args.config == Path("params/pack.json")
     assert args.config_fallback_used
+
+
+def test_load_pack_config_invalid_json(tmp_path):
+    config_path = tmp_path / "pack.json"
+    config_path.write_text("{invalid json}")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_pack_config(config_path)
+
+    assert str(config_path) in str(excinfo.value)
+
+
+@pytest.mark.skipif(config_module.yaml is None, reason="PyYAML not available")
+def test_load_pack_config_invalid_yaml(tmp_path):
+    config_path = tmp_path / "pack.yaml"
+    config_path.write_text("foo: [bar")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_pack_config(config_path)
+
+    assert str(config_path) in str(excinfo.value)


### PR DESCRIPTION
## Summary
- wrap JSON and YAML parsing in load_pack_config with ConfigError on failure to include file path context
- add regression tests confirming invalid JSON and YAML configs raise ConfigError instead of parser exceptions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb17ab1bd4832590e782af9245e3ba