### PR TITLE
Document HIP requirements for Houdini automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The Houdini pipeline converts input StarCraft assets into multi-layer EXRs using
    Run the build script headlessly via `hython`:
    ```bash
    hython houdini/generate_passes.py \
+     --hip-file <path/to/your_scene.hip> \
      --config params/pack.yaml \
      --shot shot_1001 \
      --output renders/houdini \
@@ -58,6 +59,7 @@ The Houdini pipeline converts input StarCraft assets into multi-layer EXRs using
      --render-root /out/scbw_passes \
      --exr-driver /out/scbw_exr_packager
    ```
+   Ensure the supplied HIP defines the `/obj/scbw_shot_controller1` control node, or point `--control-node` to your own controller when deviating from the default scene layout.
    The CLI loads the Houdini scene, applies the selected shot parameters, renders the RGBA/mask/Z passes, and finally assembles them into a multi-plane EXR in the requested output folder.
 4. **Dry run outside Houdini**
    For CI or quick verification, you may run the script without `hython` by enabling `--dry-run`. The script will validate configuration files and print the paths it would generate without requiring the `hou` module.

--- a/houdini/README.md
+++ b/houdini/README.md
@@ -15,6 +15,7 @@ Invoke the script with `hython`:
 
 ```bash
 hython houdini/generate_passes.py \
+  --hip-file <path/to/your_scene.hip> \
   --config params/pack.yaml \
   --shot shot_1001 \
   --output renders/houdini \
@@ -22,6 +23,9 @@ hython houdini/generate_passes.py \
   --render-root /out/scbw_passes \
   --exr-driver /out/scbw_exr_packager
 ```
+
+The example assumes your HIP contains the default control node, render root, and EXR driver; supply your scene via `--hip-file`
+and adjust the node paths if your network uses different locations.
 
 Use `--list-shots` to inspect available shot identifiers or `--dry-run` when
 running outside Houdini. The latter is useful for CI environments where `hou`


### PR DESCRIPTION
## Summary
- document the need to supply a HIP file when launching the Houdini automation
- clarify that the provided command assumes the default control, render, and EXR nodes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb1a81a6488325a8e4d06632029229