### PR TITLE
Fix PassAssembler frame range default

### DIFF
--- a/houdini/passes.py
+++ b/houdini/passes.py
@@ -77,7 +77,7 @@ class PassAssembler:
         control_node_path: Optional[str] = None,
         render_root: str = "/out/scbw_passes",
         exr_driver: Optional[str] = "/out/scbw_exr_packager",
-        frame_range: FrameRange = FrameRange(),
+        frame_range: Optional[FrameRange] = None,
     ) -> None:
         self.config = config
         self.output_directory = output_directory
@@ -85,7 +85,7 @@ class PassAssembler:
         self.control_node_path = control_node_path
         self.render_root = render_root
         self.exr_driver = exr_driver
-        self.frame_range = frame_range
+        self.frame_range = frame_range or FrameRange()
 
     # ------------------------------------------------------------------
     # High level workflow

--- a/tests/test_pass_assembler.py
+++ b/tests/test_pass_assembler.py
@@ -37,3 +37,17 @@ def test_pack_config_shots_missing_id_raises(tmp_path):
     message = str(exc_info.value)
     assert "index 0" in message
     assert str(config.path) in message
+
+
+def test_default_frame_range_isolation(tmp_path):
+    config = PackConfig(path=tmp_path / "pack.yaml", data={"shots": []})
+
+    assembler_one = PassAssembler(config=config, output_directory=tmp_path)
+    assembler_two = PassAssembler(config=config, output_directory=tmp_path)
+
+    assembler_one.frame_range.start = 10
+    assembler_one.frame_range.end = 20
+
+    assert assembler_one.frame_range.as_tuple() == (10, 20)
+    assert assembler_two.frame_range.as_tuple() == (1, 1)
+    assert assembler_one.frame_range is not assembler_two.frame_range


### PR DESCRIPTION
## Summary
- make the PassAssembler frame_range parameter optional and initialize defaults inside the constructor
- add a regression test ensuring default frame ranges are isolated between assembler instances

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb33815ae483258dc5a842fe055c24