### PR TITLE
Set default Houdini node paths

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -5,7 +5,7 @@ The following commands demonstrate common invocations of the Houdini render auto
 ```bash
 hython houdini/generate_passes.py --help
 hython houdini/generate_passes.py --list-shots
-hython houdini/generate_passes.py --config params/pack.yaml --shot shot_1001 --output renders/houdini --control-node /obj/scbw_shot_controller1 --render-root /out/scbw_passes --exr-driver /out/scbw_exr_packager
+hython houdini/generate_passes.py --config params/pack.yaml --shot shot_1001 --output renders/houdini
 hython houdini/generate_passes.py --config params/pack.yaml --shot shot_1001 --shot shot_1002 --output renders/houdini --verbose
 hython houdini/generate_passes.py --config params/pack.yaml --passes rgba mask normal --frame-range 1 24 --output renders/houdini
 hython houdini/generate_passes.py --config params/pack.yaml --hip-file path/to/scene.hip --control-node /obj/custom_controller --render-root /out/custom_passes --exr-driver /out/custom_exr
@@ -13,4 +13,4 @@ python houdini/generate_passes.py --config params/pack.yaml --dry-run --verbose
 python houdini/generate_passes.py --config params/pack.yaml --shot shot_debug --frame-range 10 12 --dry-run --verbose
 ```
 
-Each `hython` command assumes that Houdini is installed and that the scene contains the referenced control nodes. The `python` commands run the script in dry-run mode for validation without Houdini.
+Each `hython` command assumes that Houdini is installed and that the scene contains the default `/obj/scbw_shot_controller1`, `/out/scbw_passes`, and `/out/scbw_exr_packager` nodes (or that you have overridden them with custom paths). The `python` commands run the script in dry-run mode for validation without Houdini.

--- a/README.md
+++ b/README.md
@@ -55,12 +55,9 @@ The Houdini pipeline converts input StarCraft assets into multi-layer EXRs using
      --hip-file <path/to/your_scene.hip> \
      --config params/pack.yaml \
      --shot shot_1001 \
-     --output renders/houdini \
-     --control-node /obj/scbw_shot_controller1 \
-     --render-root /out/scbw_passes \
-     --exr-driver /out/scbw_exr_packager
+     --output renders/houdini
    ```
-   Ensure the supplied HIP defines the `/obj/scbw_shot_controller1` control node, or point `--control-node` to your own controller when deviating from the default scene layout.
+   The CLI defaults to `/obj/scbw_shot_controller1`, `/out/scbw_passes`, and `/out/scbw_exr_packager` for the control node, render container, and EXR packager respectively. Ensure your HIP defines nodes at those locations or override the flags with your studio-specific paths before running the automation.
    The CLI loads the Houdini scene, applies the selected shot parameters, renders the RGBA/mask/Z passes, and finally assembles them into a multi-plane EXR in the requested output folder.
 4. **Dry run outside Houdini**
    For CI or quick verification, you may run the script without `hython` by enabling `--dry-run`. The script will validate configuration files and print the paths it would generate without requiring the `hou` module.

--- a/houdini/README.md
+++ b/houdini/README.md
@@ -18,14 +18,10 @@ hython houdini/generate_passes.py \
   --hip-file <path/to/your_scene.hip> \
   --config params/pack.yaml \
   --shot shot_1001 \
-  --output renders/houdini \
-  --control-node /obj/scbw_shot_controller1 \
-  --render-root /out/scbw_passes \
-  --exr-driver /out/scbw_exr_packager
+  --output renders/houdini
 ```
-
-The example assumes your HIP contains the default control node, render root, and EXR driver; supply your scene via `--hip-file`
-and adjust the node paths if your network uses different locations.
+The CLI defaults to `/obj/scbw_shot_controller1`, `/out/scbw_passes`, and `/out/scbw_exr_packager` for the control node, render
+root, and EXR driver; supply your scene via `--hip-file` and adjust the node paths if your network uses different locations.
 
 Use `--list-shots` to inspect available shot identifiers or `--dry-run` when
 running outside Houdini. The latter is useful for CI environments where `hou`

--- a/houdini/generate_passes.py
+++ b/houdini/generate_passes.py
@@ -12,7 +12,15 @@ if __package__ in {None, ""}:  # pragma: no cover - executed when run as a scrip
     sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from houdini.config import ConfigError, PackConfig, filter_shots, list_shot_ids, load_pack_config
-from houdini.passes import FrameRange, HoudiniNotAvailableError, HoudiniSession, PassAssembler
+from houdini.passes import (
+    DEFAULT_CONTROL_NODE,
+    DEFAULT_EXR_DRIVER,
+    DEFAULT_RENDER_ROOT,
+    FrameRange,
+    HoudiniNotAvailableError,
+    HoudiniSession,
+    PassAssembler,
+)
 
 try:  # pragma: no cover - hython-only dependency
     import hou  # type: ignore
@@ -38,9 +46,21 @@ def _parse_arguments(argv: Optional[Sequence[str]] = None) -> argparse.Namespace
     parser.add_argument("--list-shots", action="store_true", help="List shots defined in the configuration and exit")
     parser.add_argument("--output", type=Path, default=Path("renders/houdini"), help="Output directory for rendered passes")
     parser.add_argument("--hip-file", type=Path, help="Optional HIP file to load before rendering")
-    parser.add_argument("--control-node", help="Houdini node path that accepts shot parameters")
-    parser.add_argument("--render-root", default="/out/scbw_passes", help="Parent node containing per-plane ROPs")
-    parser.add_argument("--exr-driver", default="/out/scbw_exr_packager", help="ROP that packs the multi-plane EXR")
+    parser.add_argument(
+        "--control-node",
+        default=DEFAULT_CONTROL_NODE,
+        help=f"Houdini node path that accepts shot parameters (default: {DEFAULT_CONTROL_NODE})",
+    )
+    parser.add_argument(
+        "--render-root",
+        default=DEFAULT_RENDER_ROOT,
+        help=f"Parent node containing per-plane ROPs (default: {DEFAULT_RENDER_ROOT})",
+    )
+    parser.add_argument(
+        "--exr-driver",
+        default=DEFAULT_EXR_DRIVER,
+        help=f"ROP that packs the multi-plane EXR (default: {DEFAULT_EXR_DRIVER})",
+    )
     parser.add_argument(
         "--passes",
         nargs="+",

--- a/houdini/passes.py
+++ b/houdini/passes.py
@@ -19,6 +19,11 @@ except Exception:  # pragma: no cover - hython-only dependency.
 LOG = logging.getLogger(__name__)
 
 
+DEFAULT_CONTROL_NODE = "/obj/scbw_shot_controller1"
+DEFAULT_RENDER_ROOT = "/out/scbw_passes"
+DEFAULT_EXR_DRIVER = "/out/scbw_exr_packager"
+
+
 class HoudiniNotAvailableError(RuntimeError):
     """Raised when the :mod:`hou` module cannot be imported."""
 
@@ -74,9 +79,9 @@ class PassAssembler:
         config: PackConfig,
         output_directory: Path,
         passes: Optional[Sequence[str]] = None,
-        control_node_path: Optional[str] = None,
-        render_root: str = "/out/scbw_passes",
-        exr_driver: Optional[str] = "/out/scbw_exr_packager",
+        control_node_path: Optional[str] = DEFAULT_CONTROL_NODE,
+        render_root: str = DEFAULT_RENDER_ROOT,
+        exr_driver: Optional[str] = DEFAULT_EXR_DRIVER,
         frame_range: Optional[FrameRange] = None,
     ) -> None:
         self.config = config


### PR DESCRIPTION
## Summary
- add shared constants for the default Houdini control, render, and packager nodes
- make the CLI default to those nodes so scenes must define or override them
- refresh documentation to call out the required defaults for HIP files

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb41b94c3c8325811cba5f5611f63e